### PR TITLE
Removed unused imports

### DIFF
--- a/go/micro/micro.go
+++ b/go/micro/micro.go
@@ -4,9 +4,7 @@ package micro
 import (
 	"github.com/micro/go-grpc"
 	"github.com/micro/go-micro"
-	"github.com/micro/go-micro/selector"
 	"github.com/micro/go-plugins/registry/kubernetes"
-	"github.com/micro/go-plugins/selector/cache"
 
 	// static selector offloads load balancing to k8s services
 	// note: requires user to create k8s services


### PR DESCRIPTION
With new update, there is no usage for selector and cache imports. It gives errors below.

```
# github.com/micro/kubernetes/go/micro
../../micro/kubernetes/go/micro/micro.go:7:2: imported and not used: "github.com/micro/go-micro/selector"
../../micro/kubernetes/go/micro/micro.go:9:2: imported and not used: "github.com/micro/go-plugins/selector/cache"
```