### PR TITLE
Remove init()

### DIFF
--- a/go/web/web.go
+++ b/go/web/web.go
@@ -16,7 +16,8 @@ import (
 	"github.com/micro/go-plugins/selector/static"
 )
 
-func init() {
+// NewService returns a web service for kubernetes
+func NewService(opts ...web.Option) web.Service {
 	// set grpc transport
 	client.DefaultClient = cli.NewClient()
 	server.DefaultServer = srv.NewServer()
@@ -30,9 +31,6 @@ func init() {
 
 	// set kubernetes registry
 	os.Setenv("MICRO_REGISTRY", "kubernetes")
-}
 
-// NewService returns a web service for kubernetes
-func NewService(opts ...web.Option) web.Service {
 	return web.NewService(opts...)
 }


### PR DESCRIPTION
If the init() is removed the package could easily be imported and used just like normal. 
Additionally it would allow you to later decide if you really want to initialize for k8s like:

```go
service := web.NewService()
if cfg.Environment == "k8s" {
    service = k8s.NewService() // k8s is this package
}
```

Signed-off-by: Lukas Jarosch <lukas.jarosch@mail.com> 