### PR TITLE
Disable namespace by default

### DIFF
--- a/cmd/micro/main.go
+++ b/cmd/micro/main.go
@@ -14,15 +14,23 @@ import (
 	// enable with MICRO_SELECTOR=static or --selector=static
 	// requires user to create k8s services
 	_ "github.com/micro/go-plugins/selector/static"
+
+	// disable namespace by default
+	"github.com/micro/micro/api"
 )
 
-func init() {
+func main() {
+	// disable namespace
+	api.Namespace = ""
+
+	// set values for registry/selector
 	os.Setenv("MICRO_REGISTRY", "kubernetes")
 	os.Setenv("MICRO_SELECTOR", "static")
+
+	// setup client/server
 	client.DefaultClient = cli.NewClient()
 	server.DefaultServer = srv.NewServer()
-}
 
-func main() {
+	// init command
 	cmd.Init()
 }


### PR DESCRIPTION
This PR explicitly disables our internal use of namespace by default on Kubernetes.

Routing via the API Gateway has always been a problem on kubernetes since we try to lookup services as namespace + path. By disabling it, we make this an optional choice. Namespace can be defined and then set in the service name but otherwise it works as expected.